### PR TITLE
Adding EF Core commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # dotnet, A Visual Studio Code extension
 
-A modern interface to the dotnet cli for Visual Studio Code.
+A modern interface to the dotnet & Entity Framework Core CLI for Visual Studio Code.
 
-This extension provides access to the dotnet cli by using the Quick Pick UI. 
+This extension provides access to the dotnet & EF CLI by using the Quick Pick UI. 
 
 ## Usage
 
@@ -30,3 +30,12 @@ This extension provides access to the dotnet cli by using the Quick Pick UI.
 
 * Add/Remove projects to/from solutions (`dotnet sln add`, `dotnet sln remove`) 
 
+### Entity Framework Core
+
+* Add/Remove migrations (`dotnet ef migrations add`, `dotnet ef migrations remove`) 
+
+* List migrations (`dotnet ef migrations list`) 
+ 
+* Update database (`dotnet ef database update`) 
+  
+* Show dbcontext info (`dotnet ef dbcontext info`) 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1231 @@
+{
+	"name": "dotnet",
+	"version": "1.3.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.10.4"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"dev": true
+		},
+		"@babel/highlight": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/runtime": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+			"requires": {
+				"regenerator-runtime": "^0.13.4"
+			}
+		},
+		"@types/glob": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+			"dev": true,
+			"requires": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
+		"@types/lodash": {
+			"version": "4.14.165",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz",
+			"integrity": "sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==",
+			"dev": true
+		},
+		"@types/lodash.debounce": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+			"integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+			"dev": true,
+			"requires": {
+				"@types/lodash": "*"
+			}
+		},
+		"@types/lodash.difference": {
+			"version": "4.5.6",
+			"resolved": "https://registry.npmjs.org/@types/lodash.difference/-/lodash.difference-4.5.6.tgz",
+			"integrity": "sha512-wXH53r+uoUCrKhmh7S5Gf6zo3vpsx/zH2R4pvkmDlmopmMTCROAUXDpPMXATGCWkCjE6ik3VZzZUxBgMjZho9Q==",
+			"dev": true,
+			"requires": {
+				"@types/lodash": "*"
+			}
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+			"dev": true
+		},
+		"@types/mocha": {
+			"version": "5.2.7",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+			"integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "10.17.46",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.46.tgz",
+			"integrity": "sha512-Tice8a+sJtlP9C1EUo0DYyjq52T37b3LexVu3p871+kfIBIN+OQ7PKPei1oF3MgF39olEpUfxaLtD+QFc1k69Q==",
+			"dev": true
+		},
+		"@types/vscode": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.51.0.tgz",
+			"integrity": "sha512-C/jZ35OT5k/rsJyAK8mS1kM++vMcm89oSWegkzxRCvHllIq0cToZAkIDs6eCY4SKrvik3nrhELizyLcM0onbQA==",
+			"dev": true
+		},
+		"agent-base": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+			"integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+			"dev": true,
+			"requires": {
+				"es6-promisify": "^5.0.0"
+			}
+		},
+		"ansi-colors": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+			"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+			"dev": true
+		},
+		"ansi-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+			"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+			"dev": true
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"axios": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+			"integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+			"requires": {
+				"follow-redirects": "1.5.10"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"browser-stdout": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+			"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+			"dev": true
+		},
+		"builtin-modules": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+			"dev": true
+		},
+		"call-bind": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+			"integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"get-intrinsic": "^1.0.0"
+			}
+		},
+		"camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"dependencies": {
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"cliui": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+			"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^3.1.0",
+				"strip-ansi": "^5.2.0",
+				"wrap-ansi": "^5.1.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+			"dev": true
+		},
+		"define-properties": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"dev": true,
+			"requires": {
+				"object-keys": "^1.0.12"
+			}
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
+		"emoji-regex": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+			"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+			"dev": true
+		},
+		"es-abstract": {
+			"version": "1.17.7",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+			"integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.2.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1",
+				"is-callable": "^1.2.2",
+				"is-regex": "^1.1.1",
+				"object-inspect": "^1.8.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.1",
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
+			},
+			"dependencies": {
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.4",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.2"
+			}
+		},
+		"es6-promise": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+			"dev": true
+		},
+		"es6-promisify": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+			"integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+			"dev": true,
+			"requires": {
+				"es6-promise": "^4.0.3"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"find-up": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"dev": true,
+			"requires": {
+				"locate-path": "^3.0.0"
+			}
+		},
+		"flat": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+			"integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+			"dev": true,
+			"requires": {
+				"is-buffer": "~2.0.3"
+			}
+		},
+		"follow-redirects": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"requires": {
+				"debug": "=3.1.0"
+			}
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
+		},
+		"get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"dev": true
+		},
+		"get-intrinsic": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+			"integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1",
+				"has": "^1.0.3",
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"growl": {
+			"version": "1.10.5",
+			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"dev": true
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"has-symbols": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+			"dev": true
+		},
+		"he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"dev": true
+		},
+		"http-proxy-agent": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
+			"integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "4",
+				"debug": "3.1.0"
+			}
+		},
+		"https-proxy-agent": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
+			"dev": true,
+			"requires": {
+				"agent-base": "^4.3.0",
+				"debug": "^3.1.0"
+			}
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+		},
+		"is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"dev": true
+		},
+		"is-callable": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+			"dev": true
+		},
+		"is-core-module": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+			"integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
+			"dev": true,
+			"requires": {
+				"has": "^1.0.3"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+			"dev": true
+		},
+		"is-fullwidth-code-point": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+			"dev": true
+		},
+		"is-negative-zero": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+			"dev": true
+		},
+		"is-regex": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"is-symbol": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+			"dev": true,
+			"requires": {
+				"has-symbols": "^1.0.1"
+			}
+		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"locate-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"dev": true,
+			"requires": {
+				"p-locate": "^3.0.0",
+				"path-exists": "^3.0.0"
+			}
+		},
+		"lodash": {
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+			"dev": true
+		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		},
+		"lodash.difference": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+		},
+		"log-symbols": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1"
+			}
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+			"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"mocha": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
+			"integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "3.2.3",
+				"browser-stdout": "1.3.1",
+				"debug": "3.2.6",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"find-up": "3.0.0",
+				"glob": "7.1.3",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.13.1",
+				"log-symbols": "2.2.0",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.4",
+				"ms": "2.1.1",
+				"node-environment-flags": "1.0.5",
+				"object.assign": "4.1.0",
+				"strip-json-comments": "2.0.1",
+				"supports-color": "6.0.0",
+				"which": "1.3.1",
+				"wide-align": "1.1.3",
+				"yargs": "13.3.2",
+				"yargs-parser": "13.1.2",
+				"yargs-unparser": "1.6.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				}
+			}
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+		},
+		"node-environment-flags": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+			"integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+			"dev": true,
+			"requires": {
+				"object.getownpropertydescriptors": "^2.0.3",
+				"semver": "^5.7.0"
+			}
+		},
+		"object-inspect": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+			"dev": true
+		},
+		"object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
+		},
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
+			}
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"dev": true,
+			"requires": {
+				"p-try": "^2.0.0"
+			}
+		},
+		"p-locate": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"dev": true,
+			"requires": {
+				"p-limit": "^2.0.0"
+			}
+		},
+		"p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"dev": true
+		},
+		"path": {
+			"version": "0.12.7",
+			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+			"integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+			"requires": {
+				"process": "^0.11.1",
+				"util": "^0.10.3"
+			}
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+			"dev": true
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+			"dev": true
+		},
+		"process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+		},
+		"promisify-child-process": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/promisify-child-process/-/promisify-child-process-3.1.4.tgz",
+			"integrity": "sha512-tLifJs99E4oOXUz/dKQjRgdchfiepmYQzBVrcVX9BtUWi9aGJeGSf2KgXOWBW1JFsSYgLkl1Z9HRm8i0sf4cTg==",
+			"requires": {
+				"@babel/runtime": "^7.1.5"
+			}
+		},
+		"regenerator-runtime": {
+			"version": "0.13.7",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+			"integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+		},
+		"require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+			"dev": true
+		},
+		"require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"dev": true
+		},
+		"resolve": {
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+			"integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+			"dev": true,
+			"requires": {
+				"is-core-module": "^2.1.0",
+				"path-parse": "^1.0.6"
+			}
+		},
+		"rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			}
+		},
+		"semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
+		},
+		"set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
+		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"string-width": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"dev": true,
+			"requires": {
+				"is-fullwidth-code-point": "^2.0.0",
+				"strip-ansi": "^4.0.0"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
+			"integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
+			}
+		},
+		"string.prototype.trimstart": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
+			"integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.18.0-next.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.18.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+					"dev": true,
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.2.2",
+						"is-negative-zero": "^2.0.0",
+						"is-regex": "^1.1.1",
+						"object-inspect": "^1.8.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.1",
+						"string.prototype.trimend": "^1.0.1",
+						"string.prototype.trimstart": "^1.0.1"
+					}
+				},
+				"object.assign": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+					"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"define-properties": "^1.1.3",
+						"has-symbols": "^1.0.1",
+						"object-keys": "^1.1.1"
+					}
+				}
+			}
+		},
+		"strip-ansi": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+			"dev": true,
+			"requires": {
+				"ansi-regex": "^3.0.0"
+			}
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
+		"supports-color": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+			"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true
+		},
+		"tslint": {
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.1.tgz",
+			"integrity": "sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"builtin-modules": "^1.1.1",
+				"chalk": "^2.3.0",
+				"commander": "^2.12.1",
+				"diff": "^4.0.1",
+				"glob": "^7.1.1",
+				"js-yaml": "^3.13.1",
+				"minimatch": "^3.0.4",
+				"mkdirp": "^0.5.1",
+				"resolve": "^1.3.2",
+				"semver": "^5.3.0",
+				"tslib": "^1.8.0",
+				"tsutils": "^2.29.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+					"dev": true
+				}
+			}
+		},
+		"tsutils": {
+			"version": "2.29.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+			"dev": true,
+			"requires": {
+				"tslib": "^1.8.1"
+			}
+		},
+		"typescript": {
+			"version": "3.9.7",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"dev": true
+		},
+		"util": {
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+			"requires": {
+				"inherits": "2.0.3"
+			}
+		},
+		"vscode-test": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.1.tgz",
+			"integrity": "sha512-Ls7+JyC06cUCuomlTYk4aNJI00Rri09hgtkNl3zfQ1bj6meXglpSPpuzJ/RPNetlUHFMm4eGs0Xr/H5pFPVwfQ==",
+			"dev": true,
+			"requires": {
+				"http-proxy-agent": "^2.1.0",
+				"https-proxy-agent": "^2.2.4",
+				"rimraf": "^2.6.3"
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"which-module": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"wide-align": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
+			"requires": {
+				"string-width": "^1.0.2 || 2"
+			}
+		},
+		"wrap-ansi": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+			"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.0",
+				"string-width": "^3.0.0",
+				"strip-ansi": "^5.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
+		},
+		"y18n": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+			"dev": true
+		},
+		"yargs": {
+			"version": "13.3.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+			"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+			"dev": true,
+			"requires": {
+				"cliui": "^5.0.0",
+				"find-up": "^3.0.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^3.0.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^13.1.2"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^7.0.1",
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^5.1.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^4.1.0"
+					}
+				}
+			}
+		},
+		"yargs-parser": {
+			"version": "13.1.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+			"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+			"dev": true,
+			"requires": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			}
+		},
+		"yargs-unparser": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+			"dev": true,
+			"requires": {
+				"flat": "^4.1.0",
+				"lodash": "^4.17.15",
+				"yargs": "^13.3.0"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,13 @@
 		"onCommand:extension.dotnet.remove.reference",
 		"onCommand:extension.dotnet.sln.add",
 		"onCommand:extension.dotnet.sln.remove",
-		"onCommand:extension.dotnet.new"
+		"onCommand:extension.dotnet.new",
+		"onCommand:extension.dotnet.ef.migrations.add",
+		"onCommand:extension.dotnet.ef.migrations.remove",
+		"onCommand:extension.dotnet.ef.migrations.list",
+		"onCommand:extension.dotnet.ef.database.update",
+		"onCommand:extension.dotnet.ef.dbcontext.info"
+
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -62,6 +68,26 @@
 			{
 				"command": "extension.dotnet.new",
 				"title": "dotnet new"
+			},
+			{
+				"command": "extension.dotnet.ef.migrations.add",
+				"title": "dotnet ef migrations add"
+			},
+			{
+				"command": "extension.dotnet.ef.migrations.remove",
+				"title": "dotnet ef migrations remove"
+			},
+			{
+				"command": "extension.dotnet.ef.migrations.list",
+				"title": "dotnet ef migrations list"
+			},
+			{
+				"command": "extension.dotnet.ef.database.update",
+				"title": "dotnet ef database update"
+			},
+			{
+				"command": "extension.dotnet.ef.dbcontext.info",
+				"title": "dotnet ef dbcontext info"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -1,121 +1,121 @@
 {
-	"name": "dotnet",
-	"displayName": "dotnet",
-	"description": "A modern wrapper around dotnet & ef cli",
-	"version": "1.3.0",
-	"publisher": "leo-labs",
-	"license": "MIT",
-	"icon": "images/icon.png",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/leo-labs/vscode-dotnet"
-	},
-	"engines": {
-		"vscode": "^1.38.0"
-	},
-	"categories": [
-		"Other"
-	],
-	"keywords": [
-		".NET Core",
-		"nuget",
-		"csharp",
-		"c#",
-		"dotnet"
-	],
-	"activationEvents": [
-		"onCommand:extension.dotnet.add.package",
-		"onCommand:extension.dotnet.remove.package",
-		"onCommand:extension.dotnet.add.reference",
-		"onCommand:extension.dotnet.remove.reference",
-		"onCommand:extension.dotnet.sln.add",
-		"onCommand:extension.dotnet.sln.remove",
-		"onCommand:extension.dotnet.new",
-		"onCommand:extension.dotnet.ef.migrations.add",
-		"onCommand:extension.dotnet.ef.migrations.remove",
-		"onCommand:extension.dotnet.ef.migrations.list",
-		"onCommand:extension.dotnet.ef.database.update",
-		"onCommand:extension.dotnet.ef.dbcontext.info"
-
-	],
-	"main": "./out/extension.js",
-	"contributes": {
-		"commands": [
-			{
-				"command": "extension.dotnet.add.package",
-				"title": "dotnet add package"
-			},
-			{
-				"command": "extension.dotnet.remove.package",
-				"title": "dotnet remove package"
-			},
-			{
-				"command": "extension.dotnet.add.reference",
-				"title": "dotnet add reference"
-			},
-			{
-				"command": "extension.dotnet.remove.reference",
-				"title": "dotnet remove reference"
-			},
-			{
-				"command": "extension.dotnet.sln.add",
-				"title": "dotnet sln add"
-			},
-			{
-				"command": "extension.dotnet.sln.remove",
-				"title": "dotnet sln remove"
-			},
-			{
-				"command": "extension.dotnet.new",
-				"title": "dotnet new"
-			},
-			{
-				"command": "extension.dotnet.ef.migrations.add",
-				"title": "dotnet ef migrations add"
-			},
-			{
-				"command": "extension.dotnet.ef.migrations.remove",
-				"title": "dotnet ef migrations remove"
-			},
-			{
-				"command": "extension.dotnet.ef.migrations.list",
-				"title": "dotnet ef migrations list"
-			},
-			{
-				"command": "extension.dotnet.ef.database.update",
-				"title": "dotnet ef database update"
-			},
-			{
-				"command": "extension.dotnet.ef.dbcontext.info",
-				"title": "dotnet ef dbcontext info"
-			}
-		]
-	},
-	"scripts": {
-		"vscode:prepublish": "yarn run compile",
-		"compile": "tsc -p ./",
-		"watch": "tsc -watch -p ./",
-		"pretest": "yarn run compile",
-		"test": "node ./out/test/runTest.js"
-	},
-	"devDependencies": {
-		"@types/glob": "^7.1.1",
-		"@types/lodash.debounce": "^4.0.6",
-		"@types/lodash.difference": "^4.5.6",
-		"@types/mocha": "^5.2.6",
-		"@types/node": "^10.12.21",
-		"@types/vscode": "^1.38.0",
-		"glob": "^7.1.4",
-		"mocha": "^6.1.4",
-		"tslint": "^5.12.1",
-		"typescript": "^3.3.1",
-		"vscode-test": "^1.2.0"
-	},
-	"dependencies": {
-		"axios": "^0.19.0",
-		"lodash.debounce": "^4.0.8",
-		"lodash.difference": "^4.5.0",
-		"path": "^0.12.7",
-		"promisify-child-process": "^3.1.3"
-	}
+  "name": "dotnet",
+  "displayName": "dotnet",
+  "description": "A modern wrapper around dotnet & ef cli",
+  "version": "1.3.0",
+  "publisher": "leo-labs",
+  "license": "MIT",
+  "icon": "images/icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leo-labs/vscode-dotnet"
+  },
+  "engines": {
+    "vscode": "^1.38.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    ".NET Core",
+    "nuget",
+    "csharp",
+    "c#",
+    "dotnet"
+  ],
+  "activationEvents": [
+    "onCommand:extension.dotnet.add.package",
+    "onCommand:extension.dotnet.remove.package",
+    "onCommand:extension.dotnet.add.reference",
+    "onCommand:extension.dotnet.remove.reference",
+    "onCommand:extension.dotnet.sln.add",
+    "onCommand:extension.dotnet.sln.remove",
+    "onCommand:extension.dotnet.new",
+    "onCommand:extension.dotnet.ef.migrations.add",
+    "onCommand:extension.dotnet.ef.migrations.remove",
+    "onCommand:extension.dotnet.ef.migrations.list",
+    "onCommand:extension.dotnet.ef.database.update",
+    "onCommand:extension.dotnet.ef.dbcontext.info"
+    
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "extension.dotnet.add.package",
+        "title": "dotnet add package"
+      },
+      {
+        "command": "extension.dotnet.remove.package",
+        "title": "dotnet remove package"
+      },
+      {
+        "command": "extension.dotnet.add.reference",
+        "title": "dotnet add reference"
+      },
+      {
+        "command": "extension.dotnet.remove.reference",
+        "title": "dotnet remove reference"
+      },
+      {
+        "command": "extension.dotnet.sln.add",
+        "title": "dotnet sln add"
+      },
+      {
+        "command": "extension.dotnet.sln.remove",
+        "title": "dotnet sln remove"
+      },
+      {
+        "command": "extension.dotnet.new",
+        "title": "dotnet new"
+      },
+      {
+        "command": "extension.dotnet.ef.migrations.add",
+        "title": "dotnet ef migrations add"
+      },
+      {
+        "command": "extension.dotnet.ef.migrations.remove",
+        "title": "dotnet ef migrations remove"
+      },
+      {
+        "command": "extension.dotnet.ef.migrations.list",
+        "title": "dotnet ef migrations list"
+      },
+      {
+        "command": "extension.dotnet.ef.database.update",
+        "title": "dotnet ef database update"
+      },
+      {
+        "command": "extension.dotnet.ef.dbcontext.info",
+        "title": "dotnet ef dbcontext info"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "yarn run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "pretest": "yarn run compile",
+    "test": "node ./out/test/runTest.js"
+  },
+  "devDependencies": {
+    "@types/glob": "^7.1.1",
+    "@types/lodash.debounce": "^4.0.6",
+    "@types/lodash.difference": "^4.5.6",
+    "@types/mocha": "^5.2.6",
+    "@types/node": "^10.12.21",
+    "@types/vscode": "^1.38.0",
+    "glob": "^7.1.4",
+    "mocha": "^6.1.4",
+    "tslint": "^5.12.1",
+    "typescript": "^3.3.1",
+    "vscode-test": "^1.2.0"
+  },
+  "dependencies": {
+    "axios": "^0.19.0",
+    "lodash.debounce": "^4.0.8",
+    "lodash.difference": "^4.5.0",
+    "path": "^0.12.7",
+    "promisify-child-process": "^3.1.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "dotnet",
 	"displayName": "dotnet",
-	"description": "A modern wrapper around dotnet cli",
+	"description": "A modern wrapper around dotnet & ef cli",
 	"version": "1.3.0",
 	"publisher": "leo-labs",
 	"license": "MIT",

--- a/src/dotnet/ef/addMigration.ts
+++ b/src/dotnet/ef/addMigration.ts
@@ -1,0 +1,39 @@
+import { window, ProgressLocation, workspace } from "vscode";
+import { selectProject, getCsprojects } from "../../util/ProjectSelector";
+import { dotnetEfAddMigration } from "../../util/execDotnet";
+
+/**
+ * Interactive Dialog using QuickPick input to add a EF migration
+ */
+export async function addMigration() {
+	const projectPath = await selectProject(getCsprojects());
+	const migrationName = await pickName();
+	return window.withProgress({
+		location: ProgressLocation.Notification,
+		title: `Scaffolding migration`,
+		cancellable: false
+	}, (progress, token) => {
+		let watcher = workspace.createFileSystemWatcher("**/*.cs");
+		watcher.onDidCreate(uri => {
+			if (uri.path.indexOf("Designer") !== undefined) {
+				workspace.openTextDocument(uri).then(doc => {
+					window.showTextDocument(doc);
+				});
+				watcher.dispose();
+			}
+		});
+
+		return dotnetEfAddMigration(projectPath, migrationName);
+	});
+}
+
+/**
+ * QuickPick dialog for choosing a name
+ */
+async function pickName() {
+	const name = await window.showInputBox({ prompt: "Specify the migration name" });
+	if (!name) {
+		throw new Error("No name chosen");
+	}
+	return name;
+}

--- a/src/dotnet/ef/addMigration.ts
+++ b/src/dotnet/ef/addMigration.ts
@@ -6,34 +6,34 @@ import { dotnetEfAddMigration } from "../../util/execDotnet";
  * Interactive Dialog using QuickPick input to add a EF migration
  */
 export async function addMigration() {
-	const projectPath = await selectProject(getCsprojects());
-	const migrationName = await pickName();
-	return window.withProgress({
-		location: ProgressLocation.Notification,
-		title: `Scaffolding migration`,
-		cancellable: false
-	}, (progress, token) => {
-		let watcher = workspace.createFileSystemWatcher("**/*.cs");
-		watcher.onDidCreate(uri => {
-			if (uri.path.indexOf("Designer") !== undefined) {
-				workspace.openTextDocument(uri).then(doc => {
-					window.showTextDocument(doc);
-				});
-				watcher.dispose();
-			}
-		});
+    const projectPath = await selectProject(getCsprojects());
+    const migrationName = await pickName();
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: `Scaffolding migration`,
+        cancellable: false
+    }, (progress, token) => {
+        let watcher = workspace.createFileSystemWatcher("**/*.cs");
+        watcher.onDidCreate(uri => {
+            if (uri.path.indexOf("Designer") !== undefined) {
+                workspace.openTextDocument(uri).then(doc => {
+                    window.showTextDocument(doc);
+                });
+                watcher.dispose();
+            }
+        });
 
-		return dotnetEfAddMigration(projectPath, migrationName);
-	});
+        return dotnetEfAddMigration(projectPath, migrationName);
+    });
 }
 
 /**
  * QuickPick dialog for choosing a name
  */
 async function pickName() {
-	const name = await window.showInputBox({ prompt: "Specify the migration name" });
-	if (!name) {
-		throw new Error("No name chosen");
-	}
-	return name;
+    const name = await window.showInputBox({ prompt: "Specify the migration name" });
+    if (!name) {
+        throw new Error("No name chosen");
+    }
+    return name;
 }

--- a/src/dotnet/ef/dbContextInfo.ts
+++ b/src/dotnet/ef/dbContextInfo.ts
@@ -1,0 +1,19 @@
+import { window, ProgressLocation } from "vscode";
+import { selectProject, getCsprojects } from "../../util/ProjectSelector";
+import { dotnetEfDbContextInfo } from "../../util/execDotnet";
+import { outputHeader } from "../../extension";
+
+/**
+ * Interactive Dialog using QuickPick input to update EF database
+ */
+export async function dbContextInfo() {
+	const projectPath = await selectProject(getCsprojects());
+	return window.withProgress({
+		location: ProgressLocation.Notification,
+		title: `Getting db context info`,
+		cancellable: false
+		}, (progress, token) => {
+			outputHeader("DOTNET EF DB CONTEXT INFO");
+			return dotnetEfDbContextInfo(projectPath);
+		});
+}

--- a/src/dotnet/ef/dbContextInfo.ts
+++ b/src/dotnet/ef/dbContextInfo.ts
@@ -7,13 +7,13 @@ import { outputHeader } from "../../extension";
  * Interactive Dialog using QuickPick input to update EF database
  */
 export async function dbContextInfo() {
-	const projectPath = await selectProject(getCsprojects());
-	return window.withProgress({
-		location: ProgressLocation.Notification,
-		title: `Getting db context info`,
-		cancellable: false
-		}, (progress, token) => {
-			outputHeader("DOTNET EF DB CONTEXT INFO");
-			return dotnetEfDbContextInfo(projectPath);
-		});
+    const projectPath = await selectProject(getCsprojects());
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: `Getting db context info`,
+        cancellable: false
+    }, (progress, token) => {
+        outputHeader("DOTNET EF DB CONTEXT INFO");
+        return dotnetEfDbContextInfo(projectPath);
+    });
 }

--- a/src/dotnet/ef/migrationsList.ts
+++ b/src/dotnet/ef/migrationsList.ts
@@ -7,13 +7,13 @@ import { outputHeader } from "../../extension";
  * Interactive Dialog using QuickPick input to update EF database
  */
 export async function migrationsList() {
-	const projectPath = await selectProject(getCsprojects());
-	return window.withProgress({
-		location: ProgressLocation.Notification,
-		title: `Getting migrations`,
-		cancellable: false
-	}, (progress, token) => {
-		outputHeader("DOTNET EF MIGRATIONS LIST");
-		return dotnetEfMigrationsList(projectPath);
-	});
+    const projectPath = await selectProject(getCsprojects());
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: `Getting migrations`,
+        cancellable: false
+    }, (progress, token) => {
+        outputHeader("DOTNET EF MIGRATIONS LIST");
+        return dotnetEfMigrationsList(projectPath);
+    });
 }

--- a/src/dotnet/ef/migrationsList.ts
+++ b/src/dotnet/ef/migrationsList.ts
@@ -1,0 +1,19 @@
+import { window, ProgressLocation } from "vscode";
+import { selectProject, getCsprojects } from "../../util/ProjectSelector";
+import { dotnetEfMigrationsList } from "../../util/execDotnet";
+import { outputHeader } from "../../extension";
+
+/**
+ * Interactive Dialog using QuickPick input to update EF database
+ */
+export async function migrationsList() {
+	const projectPath = await selectProject(getCsprojects());
+	return window.withProgress({
+		location: ProgressLocation.Notification,
+		title: `Getting migrations`,
+		cancellable: false
+	}, (progress, token) => {
+		outputHeader("DOTNET EF MIGRATIONS LIST");
+		return dotnetEfMigrationsList(projectPath);
+	});
+}

--- a/src/dotnet/ef/removeMigration.ts
+++ b/src/dotnet/ef/removeMigration.ts
@@ -1,0 +1,19 @@
+import { window, ProgressLocation } from "vscode";
+import { selectProject, getCsprojects } from "../../util/ProjectSelector";
+import { dotnetEfRemoveMigration } from "../../util/execDotnet";
+import { outputHeader } from "../../extension";
+
+/**
+ * Interactive Dialog using QuickPick input to remove EF migration
+ */
+export async function removeMigration() {
+	const projectPath = await selectProject(getCsprojects());
+	return window.withProgress({
+		location: ProgressLocation.Notification,
+		title: `Removing migration`,
+		cancellable: false
+	}, (progress, token) => {
+		outputHeader("DOTNET EF MIGRATIONS REMOVE");
+		return dotnetEfRemoveMigration(projectPath);
+	});
+}

--- a/src/dotnet/ef/removeMigration.ts
+++ b/src/dotnet/ef/removeMigration.ts
@@ -7,13 +7,13 @@ import { outputHeader } from "../../extension";
  * Interactive Dialog using QuickPick input to remove EF migration
  */
 export async function removeMigration() {
-	const projectPath = await selectProject(getCsprojects());
-	return window.withProgress({
-		location: ProgressLocation.Notification,
-		title: `Removing migration`,
-		cancellable: false
-	}, (progress, token) => {
-		outputHeader("DOTNET EF MIGRATIONS REMOVE");
-		return dotnetEfRemoveMigration(projectPath);
-	});
+    const projectPath = await selectProject(getCsprojects());
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: `Removing migration`,
+        cancellable: false
+    }, (progress, token) => {
+        outputHeader("DOTNET EF MIGRATIONS REMOVE");
+        return dotnetEfRemoveMigration(projectPath);
+    });
 }

--- a/src/dotnet/ef/updateDatabase.ts
+++ b/src/dotnet/ef/updateDatabase.ts
@@ -1,0 +1,28 @@
+import { window, ProgressLocation } from "vscode";
+import { selectProject, getCsprojects } from "../../util/ProjectSelector";
+import { dotnetEfUpdateDatabase } from "../../util/execDotnet";
+import { outputHeader } from "../../extension";
+
+/**
+ * Interactive Dialog using QuickPick input to update EF database
+ */
+export async function updateDatabase() {
+	const projectPath = await selectProject(getCsprojects());
+	const migrationName = await pickName();
+	return window.withProgress({
+		location: ProgressLocation.Notification,
+		title: `Updating database`,
+		cancellable: false
+	}, (progress, token) => {
+		outputHeader("DOTNET EF DATABASE UPDATE");
+		return dotnetEfUpdateDatabase(projectPath, migrationName);
+	});
+}
+
+/**
+ * QuickPick dialog for choosing a name
+ */
+async function pickName() {
+	const name = await window.showInputBox({ prompt: "(optional) Specify the target migration name" });
+	return name;
+}

--- a/src/dotnet/ef/updateDatabase.ts
+++ b/src/dotnet/ef/updateDatabase.ts
@@ -7,22 +7,22 @@ import { outputHeader } from "../../extension";
  * Interactive Dialog using QuickPick input to update EF database
  */
 export async function updateDatabase() {
-	const projectPath = await selectProject(getCsprojects());
-	const migrationName = await pickName();
-	return window.withProgress({
-		location: ProgressLocation.Notification,
-		title: `Updating database`,
-		cancellable: false
-	}, (progress, token) => {
-		outputHeader("DOTNET EF DATABASE UPDATE");
-		return dotnetEfUpdateDatabase(projectPath, migrationName);
-	});
+    const projectPath = await selectProject(getCsprojects());
+    const migrationName = await pickName();
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: `Updating database`,
+        cancellable: false
+    }, (progress, token) => {
+        outputHeader("DOTNET EF DATABASE UPDATE");
+        return dotnetEfUpdateDatabase(projectPath, migrationName);
+    });
 }
 
 /**
  * QuickPick dialog for choosing a name
  */
 async function pickName() {
-	const name = await window.showInputBox({ prompt: "(optional) Specify the target migration name" });
-	return name;
+    const name = await window.showInputBox({ prompt: "(optional) Specify the target migration name" });
+    return name;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,33 +15,33 @@ import { migrationsList } from './dotnet/ef/migrationsList';
 export let outputChannel: vscode.OutputChannel;
 
 export function activate(context: vscode.ExtensionContext) {
-	outputChannel = vscode.window.createOutputChannel("dotnet ef");
-	context.subscriptions.push(outputChannel);
+    outputChannel = vscode.window.createOutputChannel("dotnet ef");
+    context.subscriptions.push(outputChannel);
 
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.package',
-		async () => runAndshowErrorAsMessage(addPackage)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.package',
-		async () => runAndshowErrorAsMessage(removePackage)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.reference',
-		async () => runAndshowErrorAsMessage(addReference)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.reference',
-		async () => runAndshowErrorAsMessage(removeReference)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.add',
-		async () => runAndshowErrorAsMessage(addProject)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.remove',
-		async () => runAndshowErrorAsMessage(removeProject)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.new',
-		async () => runAndshowErrorAsMessage(newFromTemplate)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.add',
-		async () => runAndshowErrorAsMessage(addMigration)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.remove',
-		async () => runAndshowErrorAsMessage(removeMigration, true)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.database.update',
-		async () => runAndshowErrorAsMessage(updateDatabase, true)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.dbcontext.info',
-		async () => runAndshowErrorAsMessage(dbContextInfo, true)));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.list',
-		async () => runAndshowErrorAsMessage(migrationsList, true)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.package',
+        async () => runAndshowErrorAsMessage(addPackage)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.package',
+        async () => runAndshowErrorAsMessage(removePackage)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.reference',
+        async () => runAndshowErrorAsMessage(addReference)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.reference',
+        async () => runAndshowErrorAsMessage(removeReference)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.add',
+        async () => runAndshowErrorAsMessage(addProject)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.remove',
+        async () => runAndshowErrorAsMessage(removeProject)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.new',
+        async () => runAndshowErrorAsMessage(newFromTemplate)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.add',
+        async () => runAndshowErrorAsMessage(addMigration)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.remove',
+        async () => runAndshowErrorAsMessage(removeMigration, true)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.database.update',
+        async () => runAndshowErrorAsMessage(updateDatabase, true)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.dbcontext.info',
+        async () => runAndshowErrorAsMessage(dbContextInfo, true)));
+    context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.list',
+        async () => runAndshowErrorAsMessage(migrationsList, true)));
 
 }
 
@@ -49,35 +49,35 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() { }
 
 async function runAndshowErrorAsMessage(func: () => Promise<string[]>, showOutput = false) {
-	try {
-		// some operations require the display of (potentially) long output to the user
-		const output = await func();
-		if (showOutput && output.length > 0) {
-			outputMessage(output);
-		}
-	} catch (error) {
-		var message: string;
-		if (error instanceof Error) {
-			message = error.message;
-		} else {
-			message = error;
-		}
-		vscode.window.showWarningMessage(message);
-	}
+    try {
+        // some operations require the display of (potentially) long output to the user
+        const output = await func();
+        if (showOutput && output.length > 0) {
+            outputMessage(output);
+        }
+    } catch (error) {
+        var message: string;
+        if (error instanceof Error) {
+            message = error.message;
+        } else {
+            message = error;
+        }
+        vscode.window.showWarningMessage(message);
+    }
 }
 
 export function outputHeader(header: string) {
-	outputChannel.appendLine("--------------------------------------------------------------------------------");
-	outputChannel.appendLine("");
-	outputChannel.appendLine(`** ${header} **`);
-	outputChannel.appendLine("");
+    outputChannel.appendLine("--------------------------------------------------------------------------------");
+    outputChannel.appendLine("");
+    outputChannel.appendLine(`** ${header} **`);
+    outputChannel.appendLine("");
 }
 
 function outputMessage(output: string[]) {
-	output.forEach(msg => {
-		if (!msg.startsWith('Build started') && !msg.startsWith("Build succeeded")) {
-			outputChannel.appendLine(msg);
-		}
-	});
-	outputChannel.show();
+    output.forEach(msg => {
+        if (!msg.startsWith('Build started') && !msg.startsWith("Build succeeded")) {
+            outputChannel.appendLine(msg);
+        }
+    });
+    outputChannel.show();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,44 +6,78 @@ import { removeReference } from './dotnet/remove/removeReference';
 import { addProject } from './dotnet/sln/addProject';
 import { removeProject } from './dotnet/sln/removeProject';
 import { newFromTemplate } from './dotnet/new/new';
+import { addMigration } from './dotnet/ef/addMigration';
+import { removeMigration } from './dotnet/ef/removeMigration';
+import { updateDatabase } from './dotnet/ef/updateDatabase';
+import { dbContextInfo } from './dotnet/ef/dbContextInfo';
+import { migrationsList } from './dotnet/ef/migrationsList';
+
+export let outputChannel: vscode.OutputChannel;
 
 export function activate(context: vscode.ExtensionContext) {
-	
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.package', 
+	outputChannel = vscode.window.createOutputChannel("dotnet ef");
+	context.subscriptions.push(outputChannel);
+
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.package',
 		async () => runAndshowErrorAsMessage(addPackage)));
-
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.package', 
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.package',
 		async () => runAndshowErrorAsMessage(removePackage)));
-	
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.reference', 
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.add.reference',
 		async () => runAndshowErrorAsMessage(addReference)));
-
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.reference', 
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.remove.reference',
 		async () => runAndshowErrorAsMessage(removeReference)));
-	
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.add', 
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.add',
 		async () => runAndshowErrorAsMessage(addProject)));
-
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.remove', 
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.sln.remove',
 		async () => runAndshowErrorAsMessage(removeProject)));
-
-	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.new', 
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.new',
 		async () => runAndshowErrorAsMessage(newFromTemplate)));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.add',
+		async () => runAndshowErrorAsMessage(addMigration)));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.remove',
+		async () => runAndshowErrorAsMessage(removeMigration, true)));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.database.update',
+		async () => runAndshowErrorAsMessage(updateDatabase, true)));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.dbcontext.info',
+		async () => runAndshowErrorAsMessage(dbContextInfo, true)));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.dotnet.ef.migrations.list',
+		async () => runAndshowErrorAsMessage(migrationsList, true)));
+
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }
 
-async function runAndshowErrorAsMessage(func: () => Promise<string[]>) { 
+async function runAndshowErrorAsMessage(func: () => Promise<string[]>, showOutput = false) {
 	try {
-		await func();
-	} catch(error) {
-        var message: string;
-        if (error instanceof Error) {
-            message = error.message;
-        } else {
-            message = error;
-        }
-        vscode.window.showWarningMessage(message);
-    };
+		// some operations require the display of (potentially) long output to the user
+		const output = await func();
+		if (showOutput && output.length > 0) {
+			outputMessage(output);
+		}
+	} catch (error) {
+		var message: string;
+		if (error instanceof Error) {
+			message = error.message;
+		} else {
+			message = error;
+		}
+		vscode.window.showWarningMessage(message);
+	}
+}
+
+export function outputHeader(header: string) {
+	outputChannel.appendLine("--------------------------------------------------------------------------------");
+	outputChannel.appendLine("");
+	outputChannel.appendLine(`** ${header} **`);
+	outputChannel.appendLine("");
+}
+
+function outputMessage(output: string[]) {
+	output.forEach(msg => {
+		if (!msg.startsWith('Build started') && !msg.startsWith("Build succeeded")) {
+			outputChannel.appendLine(msg);
+		}
+	});
+	outputChannel.show();
 }

--- a/src/util/execDotnet.ts
+++ b/src/util/execDotnet.ts
@@ -4,23 +4,23 @@ import { exec, spawn } from 'promisify-child-process';
 /**
  * Runs `dotnet sln <solutionPath> list` to list projects referenced by the solution
  */
-export async function dotnetSlnList(solutionPath: string) : Promise<string[]> {
-	const output = await execDotnet(`sln "${solutionPath}" list`);
-	return output.slice(2, -1);
+export async function dotnetSlnList(solutionPath: string): Promise<string[]> {
+    const output = await execDotnet(`sln "${solutionPath}" list`);
+    return output.slice(2, -1);
 }
 
 /**
  * Runs `dotnet sln <solutionPath> add <projectPath>` to add a project to the solution
  */
 export async function dotnetSlnAdd(solutionPath: string, projectPath: string) {
-	return execDotnet(`sln "${solutionPath}" add "${projectPath}"`);
+    return execDotnet(`sln "${solutionPath}" add "${projectPath}"`);
 }
 
 /**
  * Runs `dotnet sln <solutionPath> remove <projectPath>` to remove a project from the solution
  */
 export async function dotnetSlnRemove(solutionPath: string, projectPath: string) {
-	return execDotnet(`sln "${solutionPath}" remove "${projectPath}"`);
+    return execDotnet(`sln "${solutionPath}" remove "${projectPath}"`);
 }
 
 /**
@@ -30,13 +30,13 @@ export async function dotnetSlnRemove(solutionPath: string, projectPath: string)
  * https://github.com/NuGet/Home/issues/7752 will make this more stable
  */
 export async function dotnetListPackages(projectPath: string) {
-	const output = await execDotnet(`list ${projectPath} package`);
-	// lines with packages start with '>'
-	return output.filter(el => el.includes(">")).map(el => {
-		// split by whitespaces into columns
-		const columns = el.split(/\s+/);
-		return ({ label: columns[2], description: columns.slice(-2)[0]});
-	});
+    const output = await execDotnet(`list ${projectPath} package`);
+    // lines with packages start with '>'
+    return output.filter(el => el.includes(">")).map(el => {
+        // split by whitespaces into columns
+        const columns = el.split(/\s+/);
+        return ({ label: columns[2], description: columns.slice(-2)[0] });
+    });
 }
 
 /**
@@ -45,8 +45,8 @@ export async function dotnetListPackages(projectPath: string) {
  * the output. 
 */
 export async function dotnetListReferences(projectPath: string) {
-	const output = await execDotnet(`list ${projectPath} reference`);
-	return output.slice(2, -1);
+    const output = await execDotnet(`list ${projectPath} reference`);
+    return output.slice(2, -1);
 }
 
 /**
@@ -55,7 +55,7 @@ export async function dotnetListReferences(projectPath: string) {
  * Runs `dotnet add <projectPath> package <packageId> -v <version>`  
  */
 export async function dotnetAddPackage(projectPath: string, packageId: string, version: string) {
-	return execDotnet(`add "${projectPath}" package ${packageId} -v ${version}`);
+    return execDotnet(`add "${projectPath}" package ${packageId} -v ${version}`);
 }
 
 /**
@@ -64,9 +64,9 @@ export async function dotnetAddPackage(projectPath: string, packageId: string, v
  * Runs `dotnet remove <projectPath> package <packageId>`  
  */
 export async function dotnetRemovePackage(projectPath: string, packageId: string) {
-	return execDotnet(`remove "${projectPath}" package ${packageId}`).then(() =>
-		execDotnet(`restore "${projectPath}"`)
-	);
+    return execDotnet(`remove "${projectPath}" package ${packageId}`).then(() =>
+        execDotnet(`restore "${projectPath}"`)
+    );
 }
 
 /**
@@ -75,7 +75,7 @@ export async function dotnetRemovePackage(projectPath: string, packageId: string
  * Runs `dotnet add <projectPath> reference <projectPath>`  
  */
 export async function dotnetAddReference(projectPath: string, referenceProjectPath: string) {
-	return execDotnet(`add "${projectPath}" reference "${referenceProjectPath}"`);
+    return execDotnet(`add "${projectPath}" reference "${referenceProjectPath}"`);
 }
 
 /**
@@ -84,7 +84,7 @@ export async function dotnetAddReference(projectPath: string, referenceProjectPa
  * Runs `dotnet remove <projectPath> reference <projectPath>`
  */
 export async function dotnetRemoveReference(projectPath: string, referenceProjectPath: string) {
-	return execDotnet(`remove "${projectPath}" reference "${referenceProjectPath}"`);
+    return execDotnet(`remove "${projectPath}" reference "${referenceProjectPath}"`);
 }
 
 /**
@@ -93,7 +93,7 @@ export async function dotnetRemoveReference(projectPath: string, referenceProjec
  * Runs `dotnet ef migration add <migrationname> -p <projectPath>`
  */
 export async function dotnetEfAddMigration(projectPath: string, migrationname: string) {
-	return execDotnet(`ef migrations add "${migrationname}" -p "${projectPath}"`);
+    return execDotnet(`ef migrations add "${migrationname}" -p "${projectPath}"`);
 }
 
 /**
@@ -102,7 +102,7 @@ export async function dotnetEfAddMigration(projectPath: string, migrationname: s
  * Runs `dotnet ef migration remove -p <projectPath>`
  */
 export async function dotnetEfRemoveMigration(projectPath: string) {
-	return execDotnet(`ef migrations remove -p "${projectPath}"`);
+    return execDotnet(`ef migrations remove -p "${projectPath}"`);
 }
 
 /**
@@ -111,7 +111,7 @@ export async function dotnetEfRemoveMigration(projectPath: string) {
  * Runs `dotnet ef migrations list -p <projectPath>`
  */
 export async function dotnetEfMigrationsList(projectPath: string) {
-	return execDotnet(`ef migrations list -p "${projectPath}"`);
+    return execDotnet(`ef migrations list -p "${projectPath}"`);
 }
 
 /**
@@ -120,12 +120,12 @@ export async function dotnetEfMigrationsList(projectPath: string) {
  * Runs `dotnet ef database update <migrationname> -p <projectPath>`
  */
 export async function dotnetEfUpdateDatabase(projectPath: string, migrationname: string | undefined) {
-	if (!migrationname) {
-		return execDotnet(`ef database update -p "${projectPath}"`);
-	}
-	else {
-		return execDotnet(`ef database update "${migrationname}" -p "${projectPath}"`);
-	}
+    if (!migrationname) {
+        return execDotnet(`ef database update -p "${projectPath}"`);
+    }
+    else {
+        return execDotnet(`ef database update "${migrationname}" -p "${projectPath}"`);
+    }
 }
 
 /**
@@ -134,7 +134,7 @@ export async function dotnetEfUpdateDatabase(projectPath: string, migrationname:
  * Runs `dotnet ef dbcontext info -p <projectPath>`
  */
 export async function dotnetEfDbContextInfo(projectPath: string) {
-	return await execDotnet(`ef dbcontext info -p "${projectPath}"`);
+    return await execDotnet(`ef dbcontext info -p "${projectPath}"`);
 }
 
 /**
@@ -143,16 +143,16 @@ export async function dotnetEfDbContextInfo(projectPath: string) {
  * Runs `dotnet new --list`
  */
 export async function dotnetNewList() {
-	const output = await execDotnet("new --list");
-	var index = output.findIndex(el => el.startsWith("------------------"));
-	return output.slice(index + 1, -1)
-		// filter out empty lines from output
-		.filter(el => el != "")
-		.map((el) => {
-			// split by at least 3 whitespaces into columns
-			const columns = el.split(/\s\s\s+/);
-			return new Template(columns[0], columns[1], columns[2]);
-		});
+    const output = await execDotnet("new --list");
+    var index = output.findIndex(el => el.startsWith("------------------"));
+    return output.slice(index + 1, -1)
+        // filter out empty lines from output
+        .filter(el => el != "")
+        .map((el) => {
+            // split by at least 3 whitespaces into columns
+            const columns = el.split(/\s\s\s+/);
+            return new Template(columns[0], columns[1], columns[2]);
+        });
 }
 
 /**
@@ -161,22 +161,22 @@ export async function dotnetNewList() {
  * Runs `dotnet new <template> -n <name> -o <output>`
  */
 export async function dotnetNew(template: string, name: string, output: string) {
-	return execDotnet(`new "${template}" -n "${name}" -o "${output}"`);
+    return execDotnet(`new "${template}" -n "${name}" -o "${output}"`);
 }
 
 /**
  * Executes the dotnet command and returns the stdout separated by line
  * @param command subcommand and arguments
  */
-async function execDotnet(command: string) : Promise<string[]> {
-	try {
-		const { stdout, stderr } = await exec(`dotnet ${command}`);
-		if(stdout) {
-			return stdout.toString('utf8').split(/\r?\n/);
-		} else {
-			return [];
-		}
-	} catch(e) {
-		throw e.message + e.stdout;
-	}
+async function execDotnet(command: string): Promise<string[]> {
+    try {
+        const { stdout, stderr } = await exec(`dotnet ${command}`);
+        if (stdout) {
+            return stdout.toString('utf8').split(/\r?\n/);
+        } else {
+            return [];
+        }
+    } catch (e) {
+        throw e.message + e.stdout;
+    }
 }

--- a/src/util/execDotnet.ts
+++ b/src/util/execDotnet.ts
@@ -5,22 +5,22 @@ import { exec, spawn } from 'promisify-child-process';
  * Runs `dotnet sln <solutionPath> list` to list projects referenced by the solution
  */
 export async function dotnetSlnList(solutionPath: string) : Promise<string[]> {
-    const output = await execDotnet(`sln "${solutionPath}" list`);
-    return output.slice(2, -1);
+	const output = await execDotnet(`sln "${solutionPath}" list`);
+	return output.slice(2, -1);
 }
 
 /**
  * Runs `dotnet sln <solutionPath> add <projectPath>` to add a project to the solution
  */
 export async function dotnetSlnAdd(solutionPath: string, projectPath: string) {
-    return execDotnet(`sln "${solutionPath}" add "${projectPath}"`);
+	return execDotnet(`sln "${solutionPath}" add "${projectPath}"`);
 }
 
 /**
  * Runs `dotnet sln <solutionPath> remove <projectPath>` to remove a project from the solution
  */
 export async function dotnetSlnRemove(solutionPath: string, projectPath: string) {
-    return execDotnet(`sln "${solutionPath}" remove "${projectPath}"`);
+	return execDotnet(`sln "${solutionPath}" remove "${projectPath}"`);
 }
 
 /**
@@ -30,13 +30,13 @@ export async function dotnetSlnRemove(solutionPath: string, projectPath: string)
  * https://github.com/NuGet/Home/issues/7752 will make this more stable
  */
 export async function dotnetListPackages(projectPath: string) {
-    const output = await execDotnet(`list ${projectPath} package`);
-    // lines with packages start with '>'
-    return output.filter(el => el.includes(">")).map(el => {
-        // split by whitespaces into columns
-        const columns = el.split(/\s+/);
-        return ({ label: columns[2], description: columns.slice(-2)[0]});
-    });
+	const output = await execDotnet(`list ${projectPath} package`);
+	// lines with packages start with '>'
+	return output.filter(el => el.includes(">")).map(el => {
+		// split by whitespaces into columns
+		const columns = el.split(/\s+/);
+		return ({ label: columns[2], description: columns.slice(-2)[0]});
+	});
 }
 
 /**
@@ -45,8 +45,8 @@ export async function dotnetListPackages(projectPath: string) {
  * the output. 
 */
 export async function dotnetListReferences(projectPath: string) {
-    const output = await execDotnet(`list ${projectPath} reference`);
-    return output.slice(2, -1);
+	const output = await execDotnet(`list ${projectPath} reference`);
+	return output.slice(2, -1);
 }
 
 /**
@@ -55,7 +55,7 @@ export async function dotnetListReferences(projectPath: string) {
  * Runs `dotnet add <projectPath> package <packageId> -v <version>`  
  */
 export async function dotnetAddPackage(projectPath: string, packageId: string, version: string) {
-    return execDotnet(`add "${projectPath}" package ${packageId} -v ${version}`);
+	return execDotnet(`add "${projectPath}" package ${packageId} -v ${version}`);
 }
 
 /**
@@ -64,18 +64,18 @@ export async function dotnetAddPackage(projectPath: string, packageId: string, v
  * Runs `dotnet remove <projectPath> package <packageId>`  
  */
 export async function dotnetRemovePackage(projectPath: string, packageId: string) {
-    return execDotnet(`remove "${projectPath}" package ${packageId}`).then(() =>
-        execDotnet(`restore "${projectPath}"`)
-    );
+	return execDotnet(`remove "${projectPath}" package ${packageId}`).then(() =>
+		execDotnet(`restore "${projectPath}"`)
+	);
 }
 
 /**
  * Add a project-to-project reference to a project
  * 
  * Runs `dotnet add <projectPath> reference <projectPath>`  
- */ 
+ */
 export async function dotnetAddReference(projectPath: string, referenceProjectPath: string) {
-    return execDotnet(`add "${projectPath}" reference "${referenceProjectPath}"`);
+	return execDotnet(`add "${projectPath}" reference "${referenceProjectPath}"`);
 }
 
 /**
@@ -84,7 +84,57 @@ export async function dotnetAddReference(projectPath: string, referenceProjectPa
  * Runs `dotnet remove <projectPath> reference <projectPath>`
  */
 export async function dotnetRemoveReference(projectPath: string, referenceProjectPath: string) {
-    return execDotnet(`remove "${projectPath}" reference "${referenceProjectPath}"`);
+	return execDotnet(`remove "${projectPath}" reference "${referenceProjectPath}"`);
+}
+
+/**
+ * EF - Add a migration
+ * 
+ * Runs `dotnet ef migration add <migrationname> -p <projectPath>`
+ */
+export async function dotnetEfAddMigration(projectPath: string, migrationname: string) {
+	return execDotnet(`ef migrations add "${migrationname}" -p "${projectPath}"`);
+}
+
+/**
+ * EF - Remove last migration
+ * 
+ * Runs `dotnet ef migration remove -p <projectPath>`
+ */
+export async function dotnetEfRemoveMigration(projectPath: string) {
+	return execDotnet(`ef migrations remove -p "${projectPath}"`);
+}
+
+/**
+ * EF - Show list of migrations
+ * 
+ * Runs `dotnet ef migrations list -p <projectPath>`
+ */
+export async function dotnetEfMigrationsList(projectPath: string) {
+	return execDotnet(`ef migrations list -p "${projectPath}"`);
+}
+
+/**
+ * EF - Update database
+ * 
+ * Runs `dotnet ef database update <migrationname> -p <projectPath>`
+ */
+export async function dotnetEfUpdateDatabase(projectPath: string, migrationname: string | undefined) {
+	if (!migrationname) {
+		return execDotnet(`ef database update -p "${projectPath}"`);
+	}
+	else {
+		return execDotnet(`ef database update "${migrationname}" -p "${projectPath}"`);
+	}
+}
+
+/**
+ * EF - DBContext Info
+ * 
+ * Runs `dotnet ef dbcontext info -p <projectPath>`
+ */
+export async function dotnetEfDbContextInfo(projectPath: string) {
+	return await execDotnet(`ef dbcontext info -p "${projectPath}"`);
 }
 
 /**
@@ -93,16 +143,16 @@ export async function dotnetRemoveReference(projectPath: string, referenceProjec
  * Runs `dotnet new --list`
  */
 export async function dotnetNewList() {
-    const output = await execDotnet("new --list");
-    var index = output.findIndex(el => el.startsWith("------------------"));
-    return output.slice(index + 1, -1)
-        // filter out empty lines from output
-        .filter(el => el != "")
-        .map((el) => {
-            // split by at least 3 whitespaces into columns
-            const columns = el.split(/\s\s\s+/);
-            return new Template(columns[0], columns[1], columns[2]);
-    });
+	const output = await execDotnet("new --list");
+	var index = output.findIndex(el => el.startsWith("------------------"));
+	return output.slice(index + 1, -1)
+		// filter out empty lines from output
+		.filter(el => el != "")
+		.map((el) => {
+			// split by at least 3 whitespaces into columns
+			const columns = el.split(/\s\s\s+/);
+			return new Template(columns[0], columns[1], columns[2]);
+		});
 }
 
 /**
@@ -111,7 +161,7 @@ export async function dotnetNewList() {
  * Runs `dotnet new <template> -n <name> -o <output>`
  */
 export async function dotnetNew(template: string, name: string, output: string) {
-    return execDotnet(`new "${template}" -n "${name}" -o "${output}"`);
+	return execDotnet(`new "${template}" -n "${name}" -o "${output}"`);
 }
 
 /**
@@ -119,14 +169,14 @@ export async function dotnetNew(template: string, name: string, output: string) 
  * @param command subcommand and arguments
  */
 async function execDotnet(command: string) : Promise<string[]> {
-    try {
-        const { stdout, stderr } = await exec(`dotnet ${command}`);
-        if(stdout) {
-            return stdout.toString('utf8').split(/\r?\n/);
-        } else {
-            return [];
-        }
-    } catch(e) {
-        throw e.message + e.stdout;
-    }
+	try {
+		const { stdout, stderr } = await exec(`dotnet ${command}`);
+		if(stdout) {
+			return stdout.toString('utf8').split(/\r?\n/);
+		} else {
+			return [];
+		}
+	} catch(e) {
+		throw e.message + e.stdout;
+	}
 }

--- a/src/util/nugetApi.ts
+++ b/src/util/nugetApi.ts
@@ -12,7 +12,7 @@ const NUGET_SEARCH_PARAM = "&take=1&prerelease=false&semVerLevel=2.0.0";
  * Includes prerelease packages
  * @param q search term for package identifier
  */
-export async function searchAutocompletePackageId(q: string) : Promise<string[]> {
+export async function searchAutocompletePackageId(q: string): Promise<string[]> {
     const query = `q=${q}`;
     return searchAutocomplete(query);
 }
@@ -22,7 +22,7 @@ export async function searchAutocompletePackageId(q: string) : Promise<string[]>
  * the package information via the `SearchQueryService` 
  * @param packageId The package identifier
  */
-export async function searchAutocompleteVersion(packageId: string) : Promise<string[]> {
+export async function searchAutocompleteVersion(packageId: string): Promise<string[]> {
     const query = `id=${packageId}`;
     return searchAutocomplete(query).then((versions) => versions.reverse());
 }
@@ -53,12 +53,12 @@ export class PackageMetadata {
  */
 export async function queryPackageMetadata(packageId: string) {
     var response = await axios.get(NUGET_SEARCH + "PackageId:" + packageId + NUGET_SEARCH_PARAM);
-    if(response.data.data.length == 0) {
+    if (response.data.data.length == 0) {
         return new PackageMetadata();
     };
 
     var data = response.data.data[0];
 
-    return new PackageMetadata(data.verified, data.versions.slice(-1)[0].version, data.description, 
+    return new PackageMetadata(data.verified, data.versions.slice(-1)[0].version, data.description,
         data.authors, data.totalDownloads);
 }

--- a/src/util/nugetApi.ts
+++ b/src/util/nugetApi.ts
@@ -12,7 +12,7 @@ const NUGET_SEARCH_PARAM = "&take=1&prerelease=false&semVerLevel=2.0.0";
  * Includes prerelease packages
  * @param q search term for package identifier
  */
-export async function searchAutocompletePackageId(q: string): Promise<string[]> {
+export async function searchAutocompletePackageId(q: string) : Promise<string[]> {
     const query = `q=${q}`;
     return searchAutocomplete(query);
 }
@@ -22,7 +22,7 @@ export async function searchAutocompletePackageId(q: string): Promise<string[]> 
  * the package information via the `SearchQueryService` 
  * @param packageId The package identifier
  */
-export async function searchAutocompleteVersion(packageId: string): Promise<string[]> {
+export async function searchAutocompleteVersion(packageId: string) : Promise<string[]> {
     const query = `id=${packageId}`;
     return searchAutocomplete(query).then((versions) => versions.reverse());
 }
@@ -53,7 +53,7 @@ export class PackageMetadata {
  */
 export async function queryPackageMetadata(packageId: string) {
     var response = await axios.get(NUGET_SEARCH + "PackageId:" + packageId + NUGET_SEARCH_PARAM);
-    if (response.data.data.length == 0) {
+    if(response.data.data.length == 0) {
         return new PackageMetadata();
     };
 


### PR DESCRIPTION
Hi,
I added new commands for Entity Framework CLI (dotnet ef).

## New commands ##
**extension.dotnet.ef.migrations.add**
1. ask user to select EF project
2. ask the user to specify migration name
3. execute the command
4. open newly created file in editor (same as Visual Studio does)

**extension.dotnet.ef.migrations.remove**
1. ask the user to select EF project
2. execute the command
3. show the result in the Output console

**extension.dotnet.ef.migrations.list**
1. ask the user to select EF project
2. execute the command
3. show the result in the Output console

**extension.dotnet.ef.database.update**
1. ask the user to select EF project
2. ask user to specify target migration name (optional)
3. execute the command
4. show the result in the Output console

**extension.dotnet.ef.dbcontext.info**
1. ask the user to select EF project
2. execute the command
3. show the result in the Output console

There are some formatting issues on my side which result in a completely changed package.json - in real I changed just description, activation events, and commands section.