### PR TITLE
Fix for dotnet new mvc command

### DIFF
--- a/src/util/execDotnet.ts
+++ b/src/util/execDotnet.ts
@@ -99,8 +99,8 @@ export async function dotnetNewList() {
         // filter out empty lines from output
         .filter(el => el != "")
         .map((el) => {
-            // split by at least 3 whitespaces into columns
-            const columns = el.split(/\s\s\s+/);
+            // split by at least 2 whitespaces into columns
+            const columns = el.split(/\s\s+/);
             return new Template(columns[0], columns[1], columns[2]);
     });
 }


### PR DESCRIPTION
The template description for mvc has only two spaces separating the template name and short name. Using 3 spaces for splitting causes the short name be treated as part of template name and language is treated as the short name.
I have changed the regex to split using two spaces instead.

This is my first open source contribution ever.  So let me know if I had missed to update anything.

Thanks,
Dilip  